### PR TITLE
Align benchmark descriptions in README and PHILOSOPHY files

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -9,59 +9,59 @@ The Gotcha Benchmark for LLMs is designed not just as a static set of tests, but
 3.  **Focus on "Gotchas":** The benchmark targets "gotcha" moments – scenarios where an LLM might appear to understand but fails due to subtle misinterpretations, reliance on statistical patterns over true reasoning, or an inability to perceive/process information like humans do.
 4.  **Transparency:** By clearly articulating the principle behind each test, we provide insights into the specific cognitive or perceptual skill being assessed.
 
-## Test Category Principles
+## Benchmark Component Principles
 
-Below are the guiding principles for each major category within the Gotcha Benchmark. We invite contributors to use these principles to create and submit new test variations.
+Below are the guiding principles for each of the four components within the Gotcha Benchmark. We invite contributors to use these principles to create and submit new test variations.
 
-### 1. VISUAL Tests
+### 1. CLOCK (Clock Image Generation)
 
-*   **Principle:** To challenge an LLM's visual understanding by presenting modified versions of known visual illusions or perception tests where the "classic" or expected answer is deliberately made incorrect. The goal is to see if the LLM truly *perceives* and *analyzes* the image, rather than relying on pre-existing knowledge about common illusions.
-*   **How it Works:** We take a well-known visual illusion (e.g., Müller-Lyer illusion, Kanizsa triangle, Rubin's vase) and alter a key feature of the image. The question posed then relates to this altered feature, leading to a different answer than the standard illusion would suggest.
+*   **Principle:** To evaluate the model's ability to understand and translate precise time-based instructions into spatially and logically accurate analog clock face images. This tests for detailed instruction adherence, numerical understanding, and visual representation of abstract concepts.
+*   **How it Works:** The model is given a specific time (e.g., "3:47") and prompted to generate an image of an analog clock displaying this time. Scoring considers the correct positioning of the hour and minute hands, and overall clock realism.
+*   **Call for Contributions:**
+    *   Propose challenging time combinations.
+    *   Suggest variations in clock style or features while maintaining the core task of accurate time representation.
+*   **Example (Conceptual):**
+    *   **Prompt:** "Generate an image of a classic analog wall clock showing the time 11:12."
+    *   **Gotcha:** The LLM might produce an image with hands in an incorrect position (e.g., hour hand directly on 11 instead of slightly past it for 12 minutes), generate a digital clock, or create an otherwise unrealistic clock face.
+
+### 2. ENIGMA (Riddles & Lateral Thinking)
+
+*   **Principle:** To evaluate the model's ability to solve verbal riddles that require critical thinking, context understanding, and bypassing obvious, statistically frequent but incorrect answers. This tests for deeper reasoning rather than surface-level pattern matching.
+*   **How it Works:** The model is presented with riddles or questions designed to have a less common but more logical answer.
+*   **Call for Contributions:** We encourage users to design textual challenges that:
+    *   Embed subtle logical traps or misdirection.
+    *   Require careful parsing of language to avoid common pitfalls.
+    *   Have answers that are non-obvious but deducible.
+*   **Example (Conceptual from benchmark):**
+    *   **Prompt:** "I have cities, but no houses. I have mountains, but no trees. I have water, but no fish. What am I?"
+    *   **Correct Answer:** A map.
+    *   **Gotcha:** An LLM might focus on the individual elements (cities, mountains, water) and fail to synthesize them into the abstract concept of a map, or provide overly literal interpretations.
+
+### 3. VISUAL (Deceptive Image Analysis)
+
+*   **Principle:** To challenge an LLM's visual understanding by presenting modified versions of known visual illusions or perception tests where the "classic" or expected answer is deliberately made incorrect. The goal is to see if the LLM truly *perceives* and *analyzes* the provided image, rather than relying on pre-existing knowledge about common illusions.
+*   **How it Works:** We take a well-known visual illusion (e.g., Müller-Lyer illusion) and alter a key feature of the image. The question posed then relates to this altered feature, leading to a different answer than the standard illusion would suggest.
 *   **Call for Contributions:** We encourage users to:
     *   Find existing visual illusions or perceptual phenomena.
     *   Modify a critical aspect of the visual.
     *   Craft a question that probes understanding of this modification.
     *   Submit their `modified_illusion.png` (or other image format) along with the question and the correct reasoning.
-*   **Example (Conceptual):**
-    *   **Original:** Standard Müller-Lyer illusion (lines appear different lengths).
-    *   **Modification:** Actually make the lines different lengths in the image file.
+*   **Example (Conceptual from benchmark):**
+    *   **Original:** Standard Müller-Lyer illusion (lines appear different lengths but are the same).
+    *   **Modification:** Actually make the lines different lengths in the image file provided to the LLM.
     *   **Question:** "Are the two horizontal lines in this image the same length or different lengths?"
-    *   **Gotcha:** The LLM might "know" the Müller-Lyer illusion and state they appear different but are the same, failing to perceive the actual modification.
+    *   **Gotcha:** The LLM might "know" the Müller-Lyer illusion and state they appear different but are the same (based on training data about the illusion), failing to perceive the actual modification in the specific image provided.
 
-### 2. AUDIO Tests
+### 4. LIPOGRAM (Constrained Writing)
 
-*   **Principle:** To test an LLM's ability to discern subtle but critical details in audio, differentiate between similar-sounding but distinct concepts, or overcome common auditory misinterpretations, especially when context or homophones are involved.
-*   **How it Works:** Audio clips are presented that contain specific challenges. These might include:
-    *   Homophones or near-homophones where context is key.
-    *   Instructions embedded within distracting noise or at low volume.
-    *   Questions about the *characteristics* of the sound (e.g., speaker's emotion, background noises) rather than just transcribed content.
-    *   Phonetic ambiguities that can lead to multiple interpretations.
-*   **Call for Contributions:** We encourage users to create and submit audio files that:
-    *   Play on common homophones (e.g., "there," "their," "they're") where the correct interpretation is only clear from a subtle contextual cue within the audio itself or the accompanying question.
-    *   Contain layered audio where a specific piece of information must be extracted from a noisy background.
-    *   Feature nuanced emotional tones or environmental sounds that must be correctly identified.
-*   **Example (Conceptual):**
-    *   **Audio:** A short clip where a voice says, "Make sure to write it right."
-    *   **Question:** "What specific spelling of 'right/write/rite' is implied by the speaker's likely intention in this audio clip?"
-    *   **Gotcha:** An LLM might transcribe correctly but fail to infer the most probable intended meaning ('write') from a typical context for such a phrase.
-
-### 3. TEXTUAL Tests
-
-*   **Principle:** To challenge an LLM's deep understanding of language beyond surface-level pattern matching. This involves tests of logical consistency, creative interpretation within constraints, identification of subtle biases or nuances, and the ability to follow complex or deliberately misleading instructions.
-*   **How it Works:** Textual prompts are designed to probe for:
-    *   **Logical Fallacies/Contradictions:** Presenting texts with internal contradictions or flawed reasoning.
-    *   **Instruction Adherence:** Giving complex, multi-step, or slightly ambiguous instructions.
-    *   **Creative Generation with Constraints:** Asking for creative output that must adhere to unusual or tricky rules (e.g., a story without the letter 'e', but the constraint is hidden).
-    *   **Metaphor/Idiom Misinterpretation:** Using figurative language in ways that might trick an LLM into a literal interpretation.
-    *   **Perspective Taking:** Requiring the LLM to answer from a specific, potentially unconventional, viewpoint.
-*   **Call for Contributions:** We encourage users to design textual challenges that:
-    *   Embed subtle logical traps.
-    *   Require careful parsing of instructions to avoid common pitfalls.
-    *   Demand creative outputs under non-obvious constraints.
-    *   Test the boundaries of figurative language understanding.
-*   **Example (Conceptual):**
-    *   **Prompt:** "Describe a cat that barks, wags its tail, and enjoys fetching sticks. However, you must not use the word 'dog' or any synonyms for it, nor imply it is a canine. The animal is, for all intents and purposes of your description, a cat."
-    *   **Question:** "Based on your description, what typical animal behaviors is this cat exhibiting?"
-    *   **Gotcha:** The LLM might struggle to maintain the "cat" identity while describing classically canine behaviors, or it might inadvertently use forbidden words/concepts.
+*   **Principle:** To evaluate an LLM's creative ability, linguistic control, and adherence to strict constraints by challenging it to write a coherent and substantial text without using a specific, common letter.
+*   **How it Works:** The model is asked to generate a piece of text (e.g., a story, an essay) of a certain length, with the explicit constraint of avoiding a particular letter (e.g., the letter 'e').
+*   **Call for Contributions:**
+    *   Propose different letters to be omitted.
+    *   Suggest various topics or styles for the lipogrammatic writing.
+    *   Define different length or complexity requirements.
+*   **Example (Conceptual from benchmark):**
+    *   **Prompt:** "Write a story of at least 100 words about a king and a magic sword, without using the letter 'a'."
+    *   **Gotcha:** The LLM might frequently use the forbidden letter, fail to produce a coherent text, or write a text that is too short, demonstrating a lack of cognitive control under constraint.
 
 By adhering to this "Benchmark by Template" philosophy, we aim to create a living, evolving, and community-strengthened tool for assessing the true capabilities and limitations of Large Language Models.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a detailed explanation of this approach and the principles behind each test 
 
 ## The Benchmarks
 
-This project is divided into three distinct tests:
+This project is divided into four distinct tests:
 
 1.  **[CLOCK (Clock)](./CLOCK/prompts.md):** Evaluates the model's ability to generate spatially and logically accurate analog clock faces from precise time prompts. See the [scoring criteria here](./CLOCK/scoring.md).
 
@@ -23,7 +23,7 @@ This project is divided into three distinct tests:
 ## How to Use This Benchmark
 
 1.  **Select a model** you wish to test.
-2.  **Run the prompts** from each of the three benchmark sections (`CLOCK`, `ENIGMA`, `VISUAL`).
+2.  **Run the prompts** from each of the four benchmark sections (`CLOCK`, `ENIGMA`, `VISUAL`, `LIPOGRAM`).
 3.  **Score the results** honestly based on the provided scoring criteria for each section.
 4.  **Share your findings!** You can submit your results by creating an "Issue" or a "Pull Request" with a new results file in the `/RESULTS` directory.
 
@@ -37,7 +37,7 @@ For a comprehensive overview of model performances, please see the [**Leaderboar
 
 ## Automated Benchmark Script
 
-This repository includes a Python script to automate the process of running the ENIGMA, VISUAL, and CLOCK benchmarks.
+This repository includes a Python script to automate the process of running three of the four benchmarks: ENIGMA, VISUAL, and CLOCK. The LIPOGRAM benchmark is currently performed manually.
 
 *   For ENIGMA and VISUAL benchmarks, it uses the Google Gemini API.
 *   For the CLOCK benchmark (image generation), it currently generates **placeholder images**. You will need to modify the script (`automation/run_benchmark.py`) to integrate a real image generation API (e.g., DALL-E, Imagen). Instructions and placeholders for API keys are in `automation/config.py` and comments within `automation/run_benchmark.py`.
@@ -68,7 +68,7 @@ Once set up, run the script from within the `automation` directory:
 ```bash
 python run_benchmark.py
 ```
-The script will execute all three benchmarks:
+The script will execute the automated benchmarks (ENIGMA, VISUAL, and CLOCK):
 *   ENIGMA and VISUAL results (text-based) will be saved in a timestamped JSON file inside the `automation/RESULTS` folder.
 *   CLOCK benchmark results (placeholder images) will be saved in the `automation/RESULTS/CLOCK_IMAGES/` directory. The JSON results file will contain paths to these images.
 


### PR DESCRIPTION
- Updated README.md to consistently refer to all four benchmark components (CLOCK, ENIGMA, VISUAL, LIPOGRAM) when listing them.
- Restructured PHILOSOPHY.md to detail the principles for each of the four named benchmarks, removing the previous broader categories and the 'AUDIO' section which has no corresponding benchmark.